### PR TITLE
fix(sw): nginx メンテ 503 を SW が上書きしないようにする

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -3093,7 +3093,7 @@ _reversi:
   useAvatarAsStone: "Turn stones into user avatars"
 _offlineScreen:
   title: "Offline - cannot connect to the server"
-  header: "Unable to connect to the server"
+  header: "Unable to connect to the server. It may be under maintenance or temporarily unavailable."
 _urlPreviewSetting:
   title: "URL preview settings"
   enable: "Enable URL preview"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -3182,7 +3182,7 @@ _reversi:
 
 _offlineScreen:
   title: "オフライン - サーバーに接続できません"
-  header: "サーバーに接続できません"
+  header: "サーバーに接続できません。メンテナンス中、または一時的に利用できない可能性があります。"
 
 _urlPreviewSetting:
   title: "URLプレビューの設定"

--- a/packages/sw/src/sw.ts
+++ b/packages/sw/src/sw.ts
@@ -22,7 +22,9 @@ async function respondToNavigation(request: Request): Promise<Response> {
 	try {
 		const response = await fetch(request, { signal: controller.signal });
 
-		if (response?.status && response.status < 500) return response;
+		// 4xx と計画メンテの 503（nginx maintenance.html）はそのまま返す。
+		// 502/504 などその他の 5xx やネットワーク失敗時のみオフライン HTML にフォールバックする。
+		if (response?.status && (response.status < 500 || response.status === 503)) return response;
 		if (response?.type === 'opaqueredirect') return response;
 	} catch (error) {
 		if (_DEV_) {
@@ -43,6 +45,8 @@ async function respondToNavigation(request: Request): Promise<Response> {
 }
 
 async function offlineContentHTML() {
+	// 計画メンテの本線は nginx の 503 + maintenance.html。
+	// ここはサーバ到達不可時（ネットワーク断など）の保険表示のみ。
 	let i18n: Partial<I18n<Locale>>;
 	try {
 		i18n = await (swLang.i18n ?? await swLang.fetchLocale()) as Partial<I18n<Locale>>;


### PR DESCRIPTION
## Summary
- 計画メンテナンスの本線は Ansible 側 nginx（[Xfolio_misskey_ansible#2](https://github.com/link-u/Xfolio_misskey_ansible/pull/2)）の 503 + `maintenance.html`
- develop の SW は 5xx をオフライン HTML に置換していたため、**503 は素通し**して nginx メンテ画面を表示できるようにする
- オフライン文言（ja/en）にメンテ可能性の一文を追加（保険表示）

仕様: [Xissmie メンテナンス画面仕様](https://app.notion.com/p/3995e0d3605d81dd8febd1791a2576fe)

## Test plan
- [ ] SW 導入済み端末で通常アクセスできる
- [ ] ネットワーク切断時にオフライン画面が出る
- [ ] nginx メンテ ON（503）時は `maintenance.html` が表示され、SW のオフライン文言で上書きされない
- [ ] 502/504 時は従来どおりオフライン画面にフォールバックする